### PR TITLE
feat: creates Divider component

### DIFF
--- a/src/components/atoms/Divider/index.tsx
+++ b/src/components/atoms/Divider/index.tsx
@@ -1,0 +1,16 @@
+interface IDivider {
+  size: 'sm' | 'lg';
+  style: 'gradient' | 'orange';
+}
+
+const Divider = ({ size, style }: IDivider) => {
+  const height = size === 'sm' ? 'h-1.3px' : size === 'lg' && 'h-1.5';
+  const bgColor =
+    style === 'gradient'
+      ? 'bg-gradient-to-r from-green to-blue.500'
+      : style === 'orange' && 'bg-orange';
+
+  return <div className={`w-full ${height} ${bgColor}`} />;
+};
+
+export { Divider };

--- a/src/components/atoms/Divider/index.tsx
+++ b/src/components/atoms/Divider/index.tsx
@@ -4,7 +4,7 @@ interface IDivider {
 }
 
 const Divider = ({ size, style }: IDivider) => {
-  const height = size === 'sm' ? 'h-1.3px' : size === 'lg' && 'h-1.5';
+  const height = size === 'sm' ? 'h-px' : size === 'lg' && 'h-1.5';
   const bgColor =
     style === 'gradient'
       ? 'bg-gradient-to-r from-green to-blue.500'

--- a/src/components/atoms/JobsSearchForm/index.tsx
+++ b/src/components/atoms/JobsSearchForm/index.tsx
@@ -1,4 +1,4 @@
-import { JobsSearchInput } from '../JobsSearchInput';
+import { JobsSearchInput, Divider } from "../index";
 import MagnifyingGlass from '../../../../public/images/magnifyingGlass.svg';
 
 const JobsSearchForm = () => {
@@ -69,7 +69,9 @@ const JobsSearchForm = () => {
           </button>
         </div>
       </div>
-      <div className="w-full h-px mt-8 bg-gradient-to-r from-green to-blue.500" />
+      <div className='mt-8 -mx-8 md:-mx-16'>
+        <Divider size='sm' style='gradient' />
+      </div>
       <span className="block mt-8 font-grotesk font-light text-xs text-gray.500 dark:text-white">
         Foi encontrado <span className="font-bold">4</span>
         &nbsp;vagas para a sua busca

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -11,3 +11,4 @@ export * from './UserButton';
 export * from './JobsSearchInput';
 export * from './JobsSearchForm';
 export * from './Card';
+export * from './Divider';

--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -1,7 +1,9 @@
+import { Divider } from '../../atoms';
 import Logo from '../../../../public/images/logo.svg';
 
 const Footer = () => (
   <footer className="bg-gray.900 mt-64">
+    <Divider size="lg" style="gradient" />
     <div className="py-12 md:py-0 md:pb-12 md:pt-14">
       <div className="w-8/12 md:w-full px-10 xl:px-24">
         <Logo fill="#fff" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,7 +71,6 @@ module.exports = {
         'searchForm': 'repeat(4, 1fr) min-content'
       },
       spacing: {
-        '1.3px': '0.08125rem',
         '17.28': '1.08rem',
         '60': '3.75rem'
       }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,6 +71,7 @@ module.exports = {
         'searchForm': 'repeat(4, 1fr) min-content'
       },
       spacing: {
+        '1.3px': '0.08125rem',
         '17.28': '1.08rem',
         '60': '3.75rem'
       }


### PR DESCRIPTION
Task: create Divider component.

Updates:
- Adds custom height to tailwind.config.js
- Creates divider and exports it
- Adds divider to JobsSearchForm and Footer components

<s>Note:
- The height of small divider is set to 1.3px (not 1px) because there's a problem with the gradient background if height is set to 1px. In some window sizes, the gradient bg disappears when the height is set to 1px.</s>

SS JobsSearchForm
![image](https://user-images.githubusercontent.com/88813381/188436898-1425bf7d-702b-40f0-9203-2fec7af7068c.png)

SS Footer
![image](https://user-images.githubusercontent.com/88813381/188436946-22754fa2-a125-46c0-bda5-d2cb07678eff.png)
